### PR TITLE
Phase 2: Migrate Databronnen → /resources/ with structured English documentation

### DIFF
--- a/Databronnen/Readme.md
+++ b/Databronnen/Readme.md
@@ -1,27 +1,16 @@
-## 📦 Custom GPT Sandbox – Bronbestanden
+> **This folder has been migrated.**
+> All content from `Databronnen/` has moved to [`/resources/`](../resources/).
+> Please update any bookmarks or links. This folder will be removed in a future release.
 
-Welkom! In deze repository verzamelen we verschillende bronbestanden, datasets en testdocumenten. Dit kun je gebruiken voor het oefenen en experimenteren met het bouwen van RAG-gebaseerde systemen.
+---
 
-Het doel van deze repo is om een dataset te publiceren om te testen met onder andere:
+## Databronnen (archived)
 
-- retrieval en document-search (RAG)
-- chunking en documentstructuur
-- prompt engineering en instructiehiërarchie
-- JSON-structuren en clausulebibliotheken
-- juridische/compliance use cases
-- consistentie en reproduceerbaarheid van output
+This folder previously contained RAG source documents for privacy, AI law, and Woo (Open Government Act) topics.
 
-Deze repository is primair bedoeld als ontwikkel- en testomgeving en de datasets zijn slechts voorbeelden van openbare en generieke data.
+The content is now available in structured, English-language format in:
 
-
-## 📁 Repository structuur
-
-Hieronder staan de verschillende mappen in deze repo, inclusief korte toelichting en links naar relevante documenten.
-
-Naast deze datasets staat op de Legal-GenAI-Resources pagina ook nog voorbeeldprompts die gebruikt kunnen worden als systeeminstructie.
-
-
-## 🧭 Notities
-- De documenten en structuur zijn bedoeld voor experimenten en kunnen wijzigen.
-- Bestanden kunnen zowel ruwe input als afgeleide versies bevatten.
-- Waar relevant worden versies en wijzigingen bijgehouden via Git.
+- [`/resources/privacy.md`](../resources/privacy.md) — GDPR / AVG documents
+- [`/resources/ai-law.md`](../resources/ai-law.md) — AI & privacy law documents
+- [`/resources/open-data.md`](../resources/open-data.md) — Woo / open government documents
+- [`/resources/README.md`](../resources/README.md) — full index

--- a/resources/README.md
+++ b/resources/README.md
@@ -1,0 +1,36 @@
+# Resources
+
+Curated references to external sources, datasets, APIs, research, and tooling relevant to Legal AI — with a focus on Dutch and European law.
+
+## Categories
+
+| File | Coverage |
+|---|---|
+| [`privacy.md`](./privacy.md) | GDPR / AVG — EDPB guidelines, data protection documents |
+| [`ai-law.md`](./ai-law.md) | AI & privacy — AP position papers, EDPB AI opinions, LLM guidance |
+| [`open-data.md`](./open-data.md) | Woo (Open Government Act) — public procurement and open data sources |
+
+## Official legal databases
+
+| Source | Description | URL |
+|---|---|---|
+| EUR-Lex | Full text of EU regulations, directives, and decisions | [eur-lex.europa.eu](https://eur-lex.europa.eu) |
+| Wettenbank.nl | Current Dutch legislation | [wetten.overheid.nl](https://wetten.overheid.nl) |
+| Rechtspraak.nl | Dutch court rulings database | [rechtspraak.nl](https://www.rechtspraak.nl) |
+| EDPB | European Data Protection Board guidelines and opinions | [edpb.europa.eu](https://edpb.europa.eu) |
+| AI Act Observatory | EU AI Act tracker and implementation resources | [artificialintelligenceact.eu](https://artificialintelligenceact.eu) |
+
+## ICTRecht publications
+
+| Publication | Description |
+|---|---|
+| [De kunst van het prompten](https://www.ictrecht.nl/hubfs/AI-onderzoek%202025/Factsheet%20prompttrucs%20voor%20juristen.pdf) | Prompting techniques for lawyers |
+| [Kun je AI vertrouwen voor juridisch werk?](https://www.ictrecht.nl/hubfs/AI-onderzoek%202025/AI-onderzoek%202025.pdf) | ICTRecht AI reliability research 2025 |
+| [AI tooling voor de juridische professional](https://www.ictrecht.nl/hubfs/Kennisdocumenten/Onderzoek/AI-tooling%20voor%20de%20legal%20professionals/Onderzoek%20AI-tooling%20voor%20de%20legal%20professionals.pdf) | Overview of AI tools for legal professionals |
+| [Richtlijnen gebruik LLMs](https://www.ictrecht.nl/hubfs/Kennisdocumenten/Richtlijnen/ICTRECHT%20ChatGPT%20Richtlijnen.pdf) | ICTRecht guidelines for LLM use |
+| [Hoe wij ChatGPT gebruiken](https://www.ictrecht.nl/hubfs/Kennisdocumenten/Hoe%20wij%20ChatGPT%20gebruiken.pdf) | How ICTRecht uses AI internally |
+| [Custom GPTs](https://www.ictrecht.nl/hubfs/Kennisdocumenten/Factsheets/Factsheet%20-%20Custom%20GPTs.pdf) | Guide to building Custom GPTs for legal work |
+
+---
+
+*This folder replaces the former `Databronnen/` folder. All content has been migrated here.*

--- a/resources/ai-law.md
+++ b/resources/ai-law.md
@@ -1,0 +1,30 @@
+# AI & Privacy Law Resources
+
+Documents and datasets for building and testing AI-law and privacy-related assistants, RAG systems, and chatbots. Sources cover Dutch supervisory authority positions and EDPB guidance on AI systems.
+
+## Dutch Data Protection Authority (AP) — AI positions
+
+| Document | Description | URL |
+|---|---|---|
+| Verder bouwen aan AI-geletterdheid | AP position on AI literacy | [autoriteitpersoonsgegevens.nl](https://www.autoriteitpersoonsgegevens.nl/documenten/verder-bouwen-aan-ai-geletterdheid) |
+| Verantwoord vooruit — AP visie op generatieve AI | AP vision on generative AI | [autoriteitpersoonsgegevens.nl](https://www.autoriteitpersoonsgegevens.nl/documenten/verantwoord-vooruit-ap-visie-op-generatieve-ai) |
+| Position paper AP — Omnibus Digitaal & Omnibus AI | AP position on EU digital omnibus packages | [autoriteitpersoonsgegevens.nl](https://www.autoriteitpersoonsgegevens.nl/documenten/position-paper-ap-omnibus-digitaal-en-omnibus-ai) |
+
+## EDPB — AI and LLM guidance
+
+| Document | Description | URL |
+|---|---|---|
+| AI Privacy Risks and Mitigations in LLMs | Technical risk analysis for LLMs | [edpb.europa.eu](https://www.edpb.europa.eu/system/files/2025-04/ai-privacy-risks-and-mitigations-in-llms.pdf) |
+| EDPB Opinion 28/2024 — AI Models (NL) | EDPB opinion on GDPR and AI models | [edpb.europa.eu](https://www.edpb.europa.eu/system/files/2025-05/edpb_opinion_202428_ai-models_nl.pdf) |
+
+## How to use these as RAG sources
+
+1. Download the documents linked above.
+2. Upload them to your AI platform's knowledge base or use them as retrieval sources.
+3. Combine with an EU AI Act or GDPR Skill from [`/skills/`](../skills/) to build a compliant AI assistant.
+
+These documents are suitable for testing:
+- AI Act compliance workflows
+- GDPR + AI intersection analysis
+- Supervisory authority position tracking
+- Multilingual (NL/EN) AI legal Q&A

--- a/resources/open-data.md
+++ b/resources/open-data.md
@@ -1,0 +1,28 @@
+# Open Government & Public Procurement Resources
+
+Documents and datasets for building and testing chatbots based on the Dutch Open Government Act (Wet open overheid, Woo) and public procurement information.
+
+## Woo documents (Open.overheid.nl)
+
+These are publicly available government documents, suitable for RAG and retrieval testing.
+
+| URL |
+|---|
+| [open.overheid.nl — document 1](https://open.overheid.nl/documenten/bdcfaef3-3f9c-4e21-99df-7ddac5728a13/file) |
+| [open.overheid.nl — document 2](https://open.overheid.nl/documenten/d1f3cade-b7a3-47d6-be66-08596a82479c/file) |
+| [open.overheid.nl — document 3](https://open.overheid.nl/documenten/dde77338-5f82-4516-b080-c96201fd8e60/file) |
+| [open.overheid.nl — document 4](https://open.overheid.nl/documenten/380c99c5-20cf-46de-92a8-e29bedcbba37/file) |
+| [open.overheid.nl — document 5](https://open.overheid.nl/documenten/26c13f9a-b417-4d34-82c3-71c90c5cf8a3/file) |
+| [open.overheid.nl — document 6](https://open.overheid.nl/documenten/a7cd0887-9f98-4271-aade-c71a2b1e2ce5/file) |
+
+## Relevant legislation
+
+| Source | Description | URL |
+|---|---|---|
+| Wet open overheid (Woo) | Full text of the Dutch Open Government Act | [wetten.overheid.nl](https://wetten.overheid.nl/BWBR0045754/) |
+
+## How to use these as RAG sources
+
+1. Download the documents from the links above.
+2. Use them as a knowledge base for a Woo-compliance or public procurement chatbot.
+3. Test retrieval quality with questions about government transparency obligations.

--- a/resources/privacy.md
+++ b/resources/privacy.md
@@ -1,0 +1,27 @@
+# Privacy & GDPR Resources
+
+Documents and datasets for building and testing GDPR-related AI assistants, RAG systems, and chatbots. All sources are publicly available official documents.
+
+## EDPB guidelines and opinions
+
+These documents can be used as knowledge base sources for privacy and GDPR chatbots or RAG systems.
+
+| Document | Language | URL |
+|---|---|---|
+| EDPB Opinion 04/2026 — BCR-C ABB | EN | [edpb.europa.eu](https://www.edpb.europa.eu/system/files/2026-02/edpb_opinion_202604_bcr-c_abb_en.pdf) |
+| EDPB Guidelines 02/2024 — Article 48 GDPR (v2) | NL | [edpb.europa.eu](https://www.edpb.europa.eu/system/files/2025-11/edpb_guidelines_202402_article48_v2_nl_0.pdf) |
+| EDPB Recommendations 01/2022 — BCR-C (v2) | NL | [edpb.europa.eu](https://www.edpb.europa.eu/system/files/2024-05/edpb_recommendations_20221_bcr-c_v2_nl.pdf) |
+| EDPB Guidelines 01/2022 — Right of Access (v2) | NL | [edpb.europa.eu](https://www.edpb.europa.eu/system/files/2024-04/edpb_guidelines_202201_data_subject_rights_access_v2_nl.pdf) |
+| EDPB Guidelines 09/2022 — Personal Data Breach Notification (v2) | NL | [edpb.europa.eu](https://www.edpb.europa.eu/system/files/2024-10/edpb_guidelines_202209_personal_data_breach_notification_v2.0_nl.pdf) |
+
+## How to use these as RAG sources
+
+1. Download the PDF documents linked above.
+2. Upload them to your AI platform's knowledge base or use them as retrieval sources.
+3. Use a privacy-focused prompt or Skill from [`/skills/`](../skills/) to query the documents.
+
+These documents are suitable for testing:
+- Retrieval and document search (RAG)
+- Chunking and document structure
+- Legal Q&A consistency
+- Multilingual (NL/EN) compliance workflows


### PR DESCRIPTION
## Summary

This PR implements **Phase 2** of the Legal GenAI Resources roadmap: migrating the existing `Databronnen/` folder to the new `/resources/` structure introduced in Phase 1.

### Changes

- **`resources/README.md`** — Full index of external legal databases (EUR-Lex, Rechtspraak.nl, Wettenbank.nl, EDPB) and all ICTRecht publications
- **`resources/privacy.md`** — Migrated from `Databronnen/Privacy.md`; EDPB guidelines and opinions reformatted as a structured table with document titles and language labels
- **`resources/ai-law.md`** — Migrated from `Databronnen/Privacy-AI.md`; AP and EDPB AI documents with descriptions added
- **`resources/open-data.md`** — Migrated from `Databronnen/WOO.md`; Woo source documents with RAG usage instructions
- **`Databronnen/Readme.md`** — Deprecation notice added pointing to the new `/resources/` location

### What's not changed

The original `Databronnen/` files (Privacy.md, Privacy-AI.md, WOO.md) are preserved intact — only the README has been updated with the deprecation notice. The folder can be removed in a later cleanup PR once all links are updated.

### Why

The `Databronnen/` name is Dutch-only and invisible to international contributors. The new `/resources/` structure uses clear English naming, adds proper descriptions to each document, and integrates with the platform README and folder overview.

## Test plan

- [ ] Verify all links in `resources/*.md` are reachable
- [ ] Verify deprecation notice in `Databronnen/Readme.md` links correctly to `/resources/`
- [ ] Confirm no existing `Databronnen/` content was lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)